### PR TITLE
Extend notifications with pages on Android Wear

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 20
     buildToolsVersion "20.0.0"
 
     defaultConfig {
         applicationId "fr.neamar.notiflow"
         minSdkVersion 16
-        targetSdkVersion 19
+        targetSdkVersion 20
     }
 
     buildTypes {
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:19.0.0'
+    compile 'com.android.support:support-v4:20.0.0'
     compile 'com.google.android.gms:play-services:5.0.89'
 }


### PR DESCRIPTION
First iteration - adding pages to wear notifications. Also did a slight bit of refactoring, just so I could understand what was going on.

Since you don't have a watch, this is what it looks like:
![image](https://cloud.githubusercontent.com/assets/4513759/4400338/5f2c34a0-447f-11e4-8f73-8306d002a0d5.png)

So that's the default notification that you've already been sending out. Nothing's changed there. Notice how the last message there cuts off, which is because of the `InboxStyle`.

That's where the second wear-only page comes in:

![image](https://cloud.githubusercontent.com/assets/4513759/4400350/88463cc8-447f-11e4-8595-4ad66200baca.png)

This also shows all pending messages, not only the last 5. Hangouts does a similar thing, where the second page will show the whole conversation, and you can keep scrolling to see even further back (not just pending). Although I don't think Hangouts is using `BigTextStyle` like I used, since the page starts at the bottom instead of top. Maybe I'll end up creating a custom layout to fix that later.
