### PR TITLE
Check if ImageLoader is already initialized.

### DIFF
--- a/app/src/main/java/fr/neamar/notiflow/GcmIntentService.java
+++ b/app/src/main/java/fr/neamar/notiflow/GcmIntentService.java
@@ -56,10 +56,7 @@ public class GcmIntentService extends IntentService {
 		super("GcmIntentService");
 	}
 
-	@Override
-	public void onCreate() {
-		super.onCreate();
-
+	private void initialiseImageLoader() {
 		ImageLoader imageLoader = ImageLoader.getInstance();
 		if(imageLoader.isInited()) {
 			return;
@@ -75,6 +72,13 @@ public class GcmIntentService extends IntentService {
 				.build();
 
 		imageLoader.init(config);
+	}
+
+	@Override
+	public void onCreate() {
+		super.onCreate();
+
+		initialiseImageLoader();
 	}
 
 	@Override


### PR DESCRIPTION
Didn't realise that `IntentService` is destroyed when it's work is done, unlike `Service`, so `onStart` is basically called on every notification. Simple check to `imageLoader.isInited()` and exit early if so.
